### PR TITLE
Jaywork

### DIFF
--- a/include/ntfs-3g/attrib.h
+++ b/include/ntfs-3g/attrib.h
@@ -380,7 +380,7 @@ extern s64 ntfs_get_attribute_value_length(const ATTR_RECORD *a);
  * then nothing was read due to a zero-length attribute value, otherwise
  * errno describes the error.
  */
-extern s64 ntfs_get_attribute_value(const ntfs_volume *vol, 
+extern s64 ntfs_get_attribute_value(const ntfs_volume *vol,
 				    const ATTR_RECORD *a, u8 *b);
 
 extern void  ntfs_attr_name_free(char **name);
@@ -398,7 +398,8 @@ extern int ntfs_attr_data_write(ntfs_inode *ni,
 		const char *buf, size_t size, off_t offset);
 extern int ntfs_attr_shrink_size(ntfs_inode *ni, ntfschar *stream_name,
 		int stream_name_len, off_t offset);
-extern int ntfs_attr_inconsistent(const ATTR_RECORD *a, const MFT_REF mref);
+extern int ntfs_attr_inconsistent(const ntfs_volume *vol, const ATTR_RECORD *a,
+	const MFT_REF mref, BOOL *fixed);
 
 #endif /* defined _NTFS_ATTRIB_H */
 

--- a/include/ntfs-3g/layout.h
+++ b/include/ntfs-3g/layout.h
@@ -740,7 +740,7 @@ typedef struct {
 /* 12*/	ATTR_FLAGS flags;	/* Flags describing the attribute. */
 /* 14*/	le16 instance;		/* The instance of this attribute record. This
 				   number is unique within this mft record (see
-				   MFT_RECORD/next_attribute_instance notes
+				   MFT_RECORD/next_attr_instance notes
 				   above for more details). */
 /* 16*/	union {
 		/* Resident attributes. */
@@ -2102,6 +2102,13 @@ typedef struct {
 /* sizeof() == 16 */
 } __attribute__((__packed__)) INDEX_HEADER;
 
+/*
+ * $INDEX_ROOT attribute structure (always resident)
+ * +--------------------------------------------------------------------+
+ * |ATTR_RECORD|INDEX_ROOT(include INDEX_HEADER)|INDEX_ENTRY| | |...
+ * +--------------------------------------------------------------------+
+ */
+
 /**
  * struct INDEX_ROOT - Attribute: Index root (0x90).
  *
@@ -2140,6 +2147,18 @@ typedef struct {
 					   following index entries. */
 /* sizeof()= 32 bytes */
 } __attribute__((__packed__)) INDEX_ROOT;
+
+/*
+ * $INDEX_ALLOCATION attribute structure (always non-resident)
+ * +------------------------------------------------------------------+
+ * |ATTR_RECORD|          data run           |
+ * +------------------------------------------------------------------+
+ *
+ * INDEX_ALLOCATION data structure
+ * +------------------------------------------------------------------+
+ * |INDEX_BLOCK(include INDEX_HEADER)|USN array|INDEX_ENTRY| | |...
+ * +------------------------------------------------------------------+
+ */
 
 /**
  * struct INDEX_BLOCK - Attribute: Index allocation (0xa0).

--- a/libntfs-3g/inode.c
+++ b/libntfs-3g/inode.c
@@ -173,6 +173,7 @@ static ntfs_inode *ntfs_inode_real_open(ntfs_volume *vol, const MFT_REF mref)
 		goto out;
 	if (ntfs_file_record_read(vol, mref, &ni->mrec, NULL))
 		goto err_out;
+
 	if (!(ni->mrec->flags & MFT_RECORD_IN_USE)) {
 		errno = ENOENT;
 		goto err_out;


### PR DESCRIPTION
1. mft entry and attribute checking more detail.
   if attribute field changed in ntfs_attr_inconsistent(), set 'fixed' flag and write mft out of function.
3. remove warning : check return value of ntfs_index_lookup().