### PR TITLE
ntfsck: attach extent inodes before using ->extent_nis

### DIFF
--- a/include/ntfs-3g/runlist.h
+++ b/include/ntfs-3g/runlist.h
@@ -65,6 +65,10 @@ extern runlist_element *ntfs_runlists_merge(runlist_element *drl,
 extern runlist_element *ntfs_mapping_pairs_decompress(const ntfs_volume *vol,
 		const ATTR_RECORD *attr, runlist_element *old_rl);
 
+extern runlist_element *ntfs_mapping_pairs_decompress_on_fsck(const ntfs_volume *vol,
+		const ATTR_RECORD *attr, runlist_element *old_rl,
+		runlist_element **part_rl);
+
 extern int ntfs_get_nr_significant_bytes(const s64 n);
 
 extern int ntfs_get_size_for_mapping_pairs(const ntfs_volume *vol,

--- a/include/ntfs-3g/volume.h
+++ b/include/ntfs-3g/volume.h
@@ -137,7 +137,7 @@ typedef enum {
 	NV_FsAutoRepair,	/* 1: Volume is for fsck */
 	NV_FsYesRepair,		/* 1: Volume is for fsck */
 	NV_FsAskRepair,		/* 1: Volume is for fsck */
-	NV_Fsck,		/* 1: Volume is for fsck */
+	NV_Fsck,		/* 1: Volume is on fsck */
 } ntfs_volume_state_bits;
 
 #define test_nvol_flag(nv, flag)	test_bit(NV_##flag, (nv)->state)
@@ -199,6 +199,8 @@ typedef enum {
 #define NVolFsck(nv)			test_nvol_flag(nv, Fsck)
 #define NVolSetFsck(nv)			set_nvol_flag(nv, Fsck)
 #define NVolClearFsck(nv)		clear_nvol_flag(nv, Fsck)
+
+#define NVolIsOnFsck(nv)		NVolFsck(nv)
 
 /*
  * NTFS version 1.1 and 1.2 are used by Windows NT4.

--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -465,15 +465,9 @@ int ntfs_index_block_inconsistent(ntfs_volume *vol, ntfs_attr *ia_na,
 	BOOL fixed = FALSE;
 
 	if (!ntfs_is_indx_record(ib->magic)) {
-		check_failed("Corrupt index block signature: vcn %lld inode "
-			       "%llu", (long long)vcn,
-			       (unsigned long long)inum);
-		if (ntfsck_ask_repair(vol)) {
-			ib->magic = magic_INDX;
-			fsck_fixes++;
-			fixed = TRUE;
-		} else
-			return -1;
+		ntfs_log_error("Corrupt index block signature: vcn(%llu) inode(%llu)\n",
+			       (long long)vcn, (unsigned long long)inum);
+		return -1;
 	}
 	
 	if (sle64_to_cpu(ib->index_block_vcn) != vcn) {

--- a/libntfs-3g/lcnalloc.c
+++ b/libntfs-3g/lcnalloc.c
@@ -725,6 +725,10 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 		// FIXME: Need to try ntfs_attr_map_runlist() for attribute
 		//	  list support! (AIA)
 		if (rl->lcn < 0 && rl->lcn != LCN_HOLE) {
+
+			if (NVolIsOnFsck(vol))
+				continue;
+
 			// FIXME: Eeek! We need rollback! (AIA)
 			errno = EIO;
 			ntfs_log_perror("%s: Invalid lcn (%lli)", 

--- a/libntfs-3g/volume.c
+++ b/libntfs-3g/volume.c
@@ -658,16 +658,6 @@ ntfs_volume *ntfs_volume_startup(struct ntfs_device *dev,
 	if (!vol)
 		goto error_exit;
 
-	if (flags & NTFS_MNT_FSCK)
-		NVolSetFsck(vol);
-
-	if (flags & NTFS_MNT_FS_YES_REPAIR)
-		NVolSetFsYesRepair(vol);
-	else if (flags & NTFS_MNT_FS_ASK_REPAIR)
-		NVolSetFsAskRepair(vol);
-	else if (flags & NTFS_MNT_FS_AUTO_REPAIR)
-		NVolSetFsAutoRepair(vol);
-	
 	/* Create the default upcase table. */
 	vol->upcase_len = ntfs_upcase_build_default(&vol->upcase);
 	if (!vol->upcase_len || !vol->upcase)

--- a/ntfsprogs/ntfsck.c
+++ b/ntfsprogs/ntfsck.c
@@ -553,6 +553,7 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 			}
 
 			/* TODO: Move orphan mft entry to lost+found directory */
+			ntfs_inode_attach_all_extents(ni);
 			while (ni->nr_extents)
 				if (ntfs_mft_record_free(vol, *(ni->extent_nis))) {
 					ntfs_log_error("Failed to free extent MFT record.  "
@@ -2203,6 +2204,7 @@ static int ntfsck_add_dir_list(ntfs_volume *vol, INDEX_ENTRY *ie,
 			goto err_out;
 		}
 
+		ntfs_inode_attach_all_extents(ni);
 		while (ext_idx < ni->nr_extents) {
 			if (ntfsck_mft_bmp_bit_set(ni->extent_nis[ext_idx]->mft_no)) {
 				ret = -1;

--- a/ntfsprogs/ntfsck.c
+++ b/ntfsprogs/ntfsck.c
@@ -699,7 +699,6 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, INDEX_ENTRY *ie,
 				le16_to_cpu(attr->value_offset));
 		filename = ntfs_attr_name_get(fn->file_name, fn->file_name_length);
 		ntfs_log_verbose("name: '%s'  type: %d\n", filename, fn->file_name_type);
-
 		if (fn->file_name_type == FILE_NAME_POSIX)
 			case_sensitive = CASE_SENSITIVE;
 		if (fn->file_name_type == ie_fn->file_name_type)
@@ -1168,7 +1167,10 @@ static int ntfsck_add_dir_list(ntfs_volume *vol, INDEX_ENTRY *ie,
 	if (!ret && ni) {
 		int ext_idx = 0;
 
-		ntfsck_check_inode(ni, ie, ictx);
+		/* skip checking for system files */
+		if (!(ni->flags & FILE_ATTR_SYSTEM)) {
+			ntfsck_check_inode(ni, ie, ictx);
+		}
 
 		if (ntfsck_mft_bmp_bit_set(MREF(mref))) {
 			ret = -1;

--- a/ntfsprogs/ntfsck.c
+++ b/ntfsprogs/ntfsck.c
@@ -608,41 +608,41 @@ void ntfsck_debug_print_fn_attr(ntfs_attr_search_ctx *actx,
 
 	if (si_mtime != mft_fn->last_data_change_time ||
 			si_mtime_mft != mft_fn->last_mft_change_time) {
-		ntfs_log_debug("STD TIME != MFT/$FN\n");
+		ntfs_log_info("STD TIME != MFT/$FN\n");
 		diff = TRUE;
 	}
 
 	if (si_mtime != ni->last_data_change_time ||
 			si_mtime_mft != ni->last_mft_change_time) {
-		ntfs_log_debug("STD TIME != INODE\n");
+		ntfs_log_info("STD TIME != INODE\n");
 		diff = TRUE;
 	}
 
 	if (si_mtime != idx_fn->last_data_change_time ||
 			si_mtime_mft != idx_fn->last_mft_change_time) {
-		ntfs_log_debug("STD TIME != IDX/$FN\n");
+		ntfs_log_info("STD TIME != IDX/$FN\n");
 		diff = TRUE;
 	}
 
 	if (idx_fn->parent_directory != mft_fn->parent_directory) {
-		ntfs_log_debug("different parent_directory IDX/$FN, MFT/$FN\n");
+		ntfs_log_info("different parent_directory IDX/$FN, MFT/$FN\n");
 		diff = TRUE;
 	}
 	if (idx_fn->allocated_size != mft_fn->allocated_size) {
-		ntfs_log_debug("different allocated_size IDX/$FN, MFT/$FN\n");
+		ntfs_log_info("different allocated_size IDX/$FN, MFT/$FN\n");
 		diff = TRUE;
 	}
 	if (idx_fn->allocated_size != mft_fn->allocated_size) {
-		ntfs_log_debug("different allocated_size IDX/$FN, MFT/$FN\n");
+		ntfs_log_info("different allocated_size IDX/$FN, MFT/$FN\n");
 		diff = TRUE;
 	}
 	if (idx_fn->data_size != mft_fn->data_size) {
-		ntfs_log_debug("different data_size IDX/$FN, MFT/$FN\n");
+		ntfs_log_info("different data_size IDX/$FN, MFT/$FN\n");
 		diff = TRUE;
 	}
 
 	if (idx_fn->reparse_point_tag != mft_fn->reparse_point_tag) {
-		ntfs_log_debug("different reparse_point IDX/$FN:%x, MFT/$FN:%x\n",
+		ntfs_log_info("different reparse_point IDX/$FN:%x, MFT/$FN:%x\n",
 				idx_fn->reparse_point_tag,
 				mft_fn->reparse_point_tag);
 		diff = TRUE;
@@ -651,19 +651,27 @@ void ntfsck_debug_print_fn_attr(ntfs_attr_search_ctx *actx,
 	if (diff == FALSE)
 		return;
 
-	ntfs_log_debug("======== START %llu ================\n", ni->mft_no);
-	ntfs_log_debug("inode ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
-			ni->creation_time, ni->last_data_change_time,
-			ni->last_mft_change_time, ni->last_access_time);
-	ntfs_log_debug("std_info ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
-			si_ctime, si_mtime, si_mtime_mft, si_atime);
-	ntfs_log_debug("mft_fn ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
-			mft_fn->creation_time, mft_fn->last_data_change_time,
-			mft_fn->last_mft_change_time, mft_fn->last_access_time);
-	ntfs_log_debug("idx_fn ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
-			idx_fn->creation_time, idx_fn->last_data_change_time,
-			idx_fn->last_mft_change_time, idx_fn->last_access_time);
-	ntfs_log_debug("======== END =======================\n");
+	ntfs_log_info("======== START %llu ================\n",
+			(unsigned long long)ni->mft_no);
+	ntfs_log_info("inode ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
+			(unsigned long long)ni->creation_time,
+			(unsigned long long)ni->last_data_change_time,
+			(unsigned long long)ni->last_mft_change_time,
+			(unsigned long long)ni->last_access_time);
+	ntfs_log_info("std_info ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
+			(unsigned long long)si_ctime, (unsigned long long)si_mtime,
+			(unsigned long long)si_mtime_mft, (unsigned long long)si_atime);
+	ntfs_log_info("mft_fn ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
+			(unsigned long long)mft_fn->creation_time,
+			(unsigned long long)mft_fn->last_data_change_time,
+			(unsigned long long)mft_fn->last_mft_change_time,
+			(unsigned long long)mft_fn->last_access_time);
+	ntfs_log_info("idx_fn ctime:%llx, mtime:%llx, mftime:%llx, atime:%llx\n",
+			(unsigned long long)idx_fn->creation_time,
+			(unsigned long long)idx_fn->last_data_change_time,
+			(unsigned long long)idx_fn->last_mft_change_time,
+			(unsigned long long)idx_fn->last_access_time);
+	ntfs_log_info("======== END =======================\n");
 
 	return;
 }


### PR DESCRIPTION
This message is comming after merging the recent PR to #master. Parse #4: Check mft entries in volume...
Clear the bit of mft no(447) in the $MFT/$BITMAP corresponding orphaned MFT record (y/N)? N

It mean fsck try to clear bits of external mft entry. When fsck set bits of mft entries, the call of ntfs_inode_attach_all_extents is missing about inode that included attrlist attribute. So fsck decided external mft entries are orphaned. This patch add the call
ntfs_inode_attach_all_extents() before checking ->nr_extents and ->extent_nis.

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>