### PR TITLE
fix inifinite loop error in adding orphaned inode

### DIFF
--- a/include/ntfs-3g/volume.h
+++ b/include/ntfs-3g/volume.h
@@ -55,12 +55,36 @@ typedef struct _ntfs_volume ntfs_volume;
 extern int fsck_errors;
 extern int fsck_fixes;
 
+/* It is called when found filesystem inconsistency */
 #define check_failed(FORMAT, ARGS...) \
 	do { \
-		fsck_errors++; \
+		fsck_err_found(); \
 		ntfs_log_redirect(__FUNCTION__, __FILE__, __LINE__, \
 				NTFS_LOG_LEVEL_ERROR, NULL, FORMAT, ##ARGS); \
-	} while (0);
+	} while (0)
+
+#define fsck_err_found() \
+	do { \
+		fsck_errors++; \
+	} while (0)
+
+/* It is called when repairing is failed */
+#define fsck_err_failed() \
+	do { \
+		fsck_errors++; \
+	} while (0)
+
+/* It is called when it turns out that doesn't need to repair */
+#define fsck_err_canceled() \
+	do { \
+		fsck_errors--; \
+	} while (0)
+
+/* It is called after repair completed */
+#define fsck_err_fixed() \
+	do { \
+		fsck_fixes++; \
+	} while (0)
 
 /**
  * enum ntfs_mount_flags -

--- a/libntfs-3g/attrib.c
+++ b/libntfs-3g/attrib.c
@@ -3533,9 +3533,9 @@ int ntfs_attr_inconsistent(const ntfs_volume *vol, const ATTR_RECORD *a,
 						"is not set to be indexed\n");
 
 				if (ntfsck_ask_repair(vol)) {
-					fsck_fixes++;
 					mod_a->resident_flags = RESIDENT_ATTR_IS_INDEXED;
 					*fixed = TRUE;
+					fsck_err_fixed();
 				}
 			}
 
@@ -3576,9 +3576,9 @@ int ntfs_attr_inconsistent(const ntfs_volume *vol, const ATTR_RECORD *a,
 						vol->indx_record_size,
 						(unsigned long long)inum);
 				if (ntfsck_ask_repair(vol)) {
-					fsck_fixes++;
 					ir->index_block_size = le32_to_cpu(vol->indx_record_size);
 					*fixed = TRUE;
+					fsck_err_fixed();
 				}
 			}
 

--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -478,8 +478,8 @@ int ntfs_index_block_inconsistent(ntfs_volume *vol, ntfs_attr *ia_na,
 			       (unsigned long long)inum);
 		if (ntfsck_ask_repair(vol)) {
 			ib->index_block_vcn = cpu_to_sle64(vcn);
-			fsck_fixes++;
 			fixed = TRUE;
+			fsck_err_fixed();
 		} else
 			return -1;
 	}
@@ -493,8 +493,8 @@ int ntfs_index_block_inconsistent(ntfs_volume *vol, ntfs_attr *ia_na,
 		if (ntfsck_ask_repair(vol)) {
 			ib->index.allocated_size = cpu_to_le32(block_size -
 				offsetof(INDEX_BLOCK, index));
-			fsck_fixes++;
 			fixed = TRUE;
+			fsck_err_fixed();
 		} else
 			return -1;
 	}
@@ -604,7 +604,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 					ictx->ir->index.ih_flags = SMALL_INDEX;
 
 				ret = 1;
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 	}
@@ -623,7 +623,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 			check_failed("INDEX_ENTRY_NODE is not set in index entry");
 			if (ntfsck_ask_repair(vol)) {
 				ie->ie_flags |= INDEX_ENTRY_NODE;
-				fsck_fixes++;
+				fsck_err_fixed();
 				ret = 1;
 			} else
 				return -1;
@@ -646,7 +646,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 
 			if (index_off <= le16_to_cpu(ie->length)) {
 				ie->key_length = index_off;
-				fsck_fixes++;
+				fsck_err_fixed();
 				ret = 1;
 			} else
 				ret = -1;
@@ -677,9 +677,8 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 		}
 
 		if (ret == -1) {
-			fsck_errors++;
+			fsck_err_found();
 			if (ntfsck_ask_repair(vol)) {
-				fsck_fixes++;
 				if (collation_rule == COLLATION_FILE_NAME) {
 					ie->key.file_name.file_name_length = ie->key_length / sizeof(ntfschar);
 				} else {
@@ -690,6 +689,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 
 					ie->data_length = cpu_to_le16(data_length);
 				}
+				fsck_err_fixed();
 				ret = 1;
 			}
 		}
@@ -2222,7 +2222,7 @@ INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
 			if (ret > 0) {
 				ret = ntfsck_update_index_entry(ictx);
 				if (ret) {
-					fsck_errors++;
+					fsck_err_failed();
 					entry = NULL;
 				}
 			}
@@ -2341,7 +2341,7 @@ INDEX_ENTRY *ntfs_index_next(INDEX_ENTRY *ie, ntfs_index_context *ictx)
 		if (ret > 0) {
 			ret = ntfsck_update_index_entry(ictx);
 			if (ret) {
-				fsck_errors++;
+				fsck_err_failed();
 				return NULL;
 			}
 		}
@@ -2369,7 +2369,7 @@ INDEX_ENTRY *ntfs_index_next(INDEX_ENTRY *ie, ntfs_index_context *ictx)
 		if (ret > 0) {
 			ret = ntfsck_update_index_entry(ictx);
 			if (ret) {
-				fsck_errors++;
+				fsck_err_failed();
 				next = (INDEX_ENTRY*)NULL;
 			}
 		}

--- a/libntfs-3g/mft.c
+++ b/libntfs-3g/mft.c
@@ -252,8 +252,8 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 
 			if (ntfsck_ask_repair(vol)) {
 				m->magic = magic_FILE;
-				fsck_fixes++;
 				fixed = TRUE;
+				fsck_err_fixed();
 			} else
 				goto err_out;
 		} else if (!NVolNoFixupWarn(vol))
@@ -271,8 +271,8 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 				     le32_to_cpu(m->bytes_allocated));
 			if (ntfsck_ask_repair(vol)) {
 				m->bytes_allocated = cpu_to_le32(vol->mft_record_size);
-				fsck_fixes++;
 				fixed = TRUE;
+				fsck_err_fixed();
 			} else
 				goto err_out;
 		} else {
@@ -286,10 +286,10 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 	/* check bytes_in_use is aligned */
 	biu = le32_to_cpu(m->bytes_in_use);
 	if (biu & 7) {
-		ntfs_log_error("Used size of MFT record is badly aligned "
+		check_failed("Used size of MFT record is badly aligned "
 				"in record %llu\n",
 			       (unsigned long long)MREF(mref));
-		fsck_errors++;
+		fsck_err_found();
 		goto err_out;
 	}
 
@@ -298,7 +298,7 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 		ntfs_log_error("Record %llu has corrupt in-use size "
 			       "(%u > %u)\n", (unsigned long long)MREF(mref),
 			       (int)biu, (int)vol->mft_record_size);
-		fsck_errors++;
+		fsck_err_found();
 		goto err_out;
 	}
 
@@ -310,7 +310,7 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 	if (offset & 7) {
 		ntfs_log_error("Attributes badly aligned in record %llu\n",
 			       (unsigned long long)MREF(mref));
-		fsck_errors++;
+		fsck_err_found();
 		goto err_out;
 	}
 
@@ -318,7 +318,7 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 		ntfs_log_error("MFT record(%llu)'s attribute start offset "
 				"is corrupted\n",
 				(unsigned long long)MREF(mref));
-		fsck_errors++;
+		fsck_err_found();
 		goto err_out;
 	}
 
@@ -327,7 +327,7 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 	if (p2n(a) < p2n(m) || (char *)a > (char *)m + vol->mft_record_size) {
 		ntfs_log_error("Record %llu is corrupt\n",
 			       (unsigned long long)MREF(mref));
-		fsck_errors++;
+		fsck_err_found();
 		goto err_out;
 	}
 
@@ -352,7 +352,7 @@ int ntfs_mft_record_check(const ntfs_volume *vol, const MFT_REF mref,
 			} else {
 				ntfs_log_error("Corrupted MFT record %llu\n",
 				       (unsigned long long)MREF(mref));
-				fsck_errors++;
+				fsck_err_found();
 				goto err_out;
 			}
 		}

--- a/libntfs-3g/volume.c
+++ b/libntfs-3g/volume.c
@@ -616,7 +616,7 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 				ntfs_log_error("Boot sector: failed to fix boot sector\n");
 				return res;
 			} else
-				fsck_fixes++;
+				fsck_err_fixed();
 		} else if (res) {
 			return 1;
 		}
@@ -1178,7 +1178,7 @@ ntfs_volume *ntfs_device_mount(struct ntfs_device *dev, ntfs_mount_flags flags)
 							use_mirr ? "" : "Mirr");
 					goto io_error_exit;
 				}
-				fsck_fixes++;
+				fsck_err_fixed();
 			} else {
 				goto io_error_exit;
 			}

--- a/ntfsprogs/ntfsck.c
+++ b/ntfsprogs/ntfsck.c
@@ -300,7 +300,7 @@ static void ntfsck_check_orphaned_clusters(ntfs_volume *vol)
 					if (ntfsck_ask_repair(vol)) {
 						ntfs_bit_set(bm, i * 8 + cl % 8, !lbmp_bit);
 						repair = TRUE;
-						fsck_fixes++;
+						fsck_err_fixed();
 					}
 				}
 			}
@@ -538,7 +538,7 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 						errno);
 				return;
 			}
-			fsck_fixes++;
+			fsck_err_fixed();
 		}
 		return;
 	}
@@ -548,7 +548,7 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 				mft_num);
 		if (ntfsck_ask_repair(vol)) {
 			if (!ntfsck_add_index_entry_orphaned_file(vol, ni->mft_no)) {
-				fsck_fixes++;
+				fsck_err_fixed();
 				goto update_lcn_bitmap;
 			}
 
@@ -562,7 +562,7 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 			if (ntfs_mft_record_free(vol, ni))
 				ntfs_log_error("Failed to free MFT record.  "
 						"Leaving inconsistent metadata. Run chkdsk.\n");
-			fsck_fixes++;
+			fsck_err_fixed();
 			return;
 		}
 	}
@@ -824,7 +824,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 				ntfs_index_entry_mark_dirty(ictx);
 				ntfs_inode_mark_dirty(ni);
 				NInoFileNameSetDirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 
@@ -876,7 +876,7 @@ fix_index:
 			}
 
 			ntfs_index_entry_mark_dirty(ictx);
-			fsck_fixes++;
+			fsck_err_fixed();
 		}
 	}
 
@@ -1023,7 +1023,7 @@ retry:
 			if (ntfsck_ask_repair(vol)) {
 				if (ntfs_non_resident_attr_shrink(na, newsize))
 					goto close_na;
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 #endif
 		} else {
@@ -1118,7 +1118,7 @@ retry:
 				}
 				ntfs_attr_put_search_ctx(actx);
 				ntfs_inode_mark_dirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 				goto retry;
 			}
 		}
@@ -1214,7 +1214,7 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 				ie_fn->file_attributes |= FILE_ATTR_I30_INDEX_PRESENT;
 				if (ntfsck_ask_repair(vol)) {
 					ntfs_index_entry_mark_dirty(ictx);
-					fsck_fixes++;
+					fsck_err_fixed();
 				}
 			}
 		} else {
@@ -1233,7 +1233,7 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 			ni->mrec->flags &= ~MFT_RECORD_IS_DIRECTORY;
 			if (ntfsck_ask_repair(vol)) {
 				ntfs_inode_mark_dirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 
 			if (ie_flags & FILE_ATTR_I30_INDEX_PRESENT) {
@@ -1245,7 +1245,7 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 				ie_fn->file_attributes &= ~FILE_ATTR_I30_INDEX_PRESENT;
 				if (ntfsck_ask_repair(vol)) {
 					ntfs_index_entry_mark_dirty(ictx);
-					fsck_fixes++;
+					fsck_err_fixed();
 				}
 			}
 #endif
@@ -1264,7 +1264,7 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 				ie_fn->file_attributes &= ~FILE_ATTR_I30_INDEX_PRESENT;
 				if (ntfsck_ask_repair(vol)) {
 					ntfs_index_entry_mark_dirty(ictx);
-					fsck_fixes++;
+					fsck_err_fixed();
 				}
 			}
 		} else {
@@ -1289,7 +1289,7 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 			ie_fn->file_attributes |= FILE_ATTR_I30_INDEX_PRESENT;
 			if (ntfsck_ask_repair(vol)) {
 				ntfs_index_entry_mark_dirty(ictx);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 	}
@@ -1471,7 +1471,7 @@ static runlist_element *ntfsck_decompose_mp(ntfs_attr *na, BOOL *need_fix)
 							(unsigned long long)ni->mft_no,
 							attr->type);
 				}
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 			continue;
 		}
@@ -1512,7 +1512,7 @@ static runlist_element *ntfsck_decompose_mp(ntfs_attr *na, BOOL *need_fix)
 								(unsigned long long)ni->mft_no,
 								attr->type);
 					}
-					fsck_fixes++;
+					fsck_err_fixed();
 					continue;
 				}
 			}
@@ -1529,7 +1529,7 @@ static runlist_element *ntfsck_decompose_mp(ntfs_attr *na, BOOL *need_fix)
 				if (ntfsck_ask_repair(vol)) {
 					attr->lowest_vcn = 0;
 					NInoSetDirty(ni);
-					fsck_fixes++;
+					fsck_err_fixed();
 				}
 				break;
 			}
@@ -1834,7 +1834,7 @@ static int ntfsck_check_directory(ntfs_inode *ni)
 			if (ntfsck_truncate_attr(ia_na, tr_size))
 				goto init_all;
 
-			fsck_fixes++;
+			fsck_err_fixed();
 		}
 	}
 
@@ -1889,7 +1889,7 @@ static int ntfsck_check_directory(ntfs_inode *ni)
 				if (ntfsck_truncate_attr(bm_na, tr_size))
 					goto init_all;
 
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 	}
@@ -1921,7 +1921,7 @@ static int ntfsck_check_directory(ntfs_inode *ni)
 				(unsigned long long)ni->mft_no);
 		if (ntfsck_ask_repair(vol)) {
 			ntfs_attr_pwrite(bm_na, pos, 8, fsck_ibm + pos);
-			fsck_fixes++;
+			fsck_err_fixed();
 		}
 		pos += 8;
 	}
@@ -1947,7 +1947,7 @@ init_all:
 		ntfs_attr_close(ia_na);
 
 	ntfsck_initialize_index_attr(ni);
-	fsck_fixes++;
+	fsck_err_fixed();
 	return ret;
 }
 
@@ -2003,7 +2003,7 @@ static int ntfsck_check_file(ntfs_inode *ni)
 				ni->allocated_size = na->allocated_size;
 				ni->data_size = na->data_size;
 				ntfs_inode_mark_dirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 			goto attr_close;
 		}
@@ -2041,7 +2041,7 @@ static int ntfsck_check_file(ntfs_inode *ni)
 				}
 				ntfs_inode_mark_dirty(ni);
 				NInoFileNameSetDirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 
@@ -2061,7 +2061,7 @@ static int ntfsck_check_file(ntfs_inode *ni)
 			ni->allocated_size = na->compressed_size;
 			ntfs_inode_mark_dirty(ni);
 			NInoFileNameSetDirty(ni);
-			fsck_fixes++;
+			fsck_err_fixed();
 		}
 	} else {
 		if ((si_flags & (FILE_ATTR_SPARSE_FILE | FILE_ATTR_COMPRESSED)) ||
@@ -2079,7 +2079,7 @@ static int ntfsck_check_file(ntfs_inode *ni)
 
 				ntfs_inode_mark_dirty(ni);
 				NInoFileNameSetDirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 
@@ -2101,7 +2101,7 @@ static int ntfsck_check_file(ntfs_inode *ni)
 				ni->allocated_size = na->allocated_size;
 				ntfs_inode_mark_dirty(ni);
 				NInoFileNameSetDirty(ni);
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 		}
 	}
@@ -2243,7 +2243,7 @@ remove_index:
 				ntfs_log_verbose("Index entry of inode(%llu:%s) is deleted\n",
 						(unsigned long long)MREF(mref), filename);
 				ret = 1;
-				fsck_fixes++;
+				fsck_err_fixed();
 			}
 			ntfs_inode_mark_dirty(ictx->actx->ntfs_ino);
 
@@ -2349,7 +2349,7 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 		if (ret > 0) {
 			ret = ntfsck_update_index_entry(ictx);
 			if (ret) {
-				fsck_errors++;
+				fsck_err_failed();
 				goto err_out;
 			}
 		}


### PR DESCRIPTION
Adding index of orphaned inode also includes it's parent inode, but in case that parent inode is already deleted in previous logic, it can put into infinite loop.

So, add handling code for deleted parent inode of orphaned inode.
(now remove all sub-inodes of deleted parent inode, but later we should add index to directory for repairing like as FOUND.000)