### PR TITLE
fix address sanitizer memory leak issues

### DIFF
--- a/include/ntfs-3g/index.h
+++ b/include/ntfs-3g/index.h
@@ -71,13 +71,14 @@ typedef int (*COLLATE)(ntfs_volume *vol, const void *data1, int len1,
  * @ni:			inode containing the @entry described by this context
  * @name:		name of the index described by this context
  * @name_len:		length of the index name
- * @entry:		index entry (points into @ir or @ia)
+ * @entry:		index entry (points into @ir or @ib)
  * @data:		index entry data (points into @entry)
  * @data_len:		length in bytes of @data
- * @is_in_root:		TRUE if @entry is in @ir or FALSE if it is in @ia
+ * @is_in_root:		TRUE if @entry is in @ir or FALSE if it is in @ib
  * @ir:			index root if @is_in_root or NULL otherwise
  * @actx:		attribute search context if in root or NULL otherwise
- * @ia:			index block if @is_in_root is FALSE or NULL otherwise
+ * @ib:			index block if @is_in_root is FALSE or NULL otherwise
+ * @prev_ib:		to retain previous index block if new index block read to @ib
  * @ia_na:		opened INDEX_ALLOCATION attribute
  * @parent_pos:		parent entries' positions in the index block
  * @parent_vcn:		entry's parent node or VCN_INDEX_ROOT_PARENT
@@ -124,6 +125,7 @@ typedef struct {
 	INDEX_ROOT *ir;
 	ntfs_attr_search_ctx *actx;
 	INDEX_BLOCK *ib;
+	INDEX_BLOCK *prev_ib;		/* for fsck, retain previous block */
 	ntfs_attr *ia_na;
 	int parent_pos[MAX_PARENT_VCN];  /* parent entries' positions */
 	VCN parent_vcn[MAX_PARENT_VCN]; /* entry's parent nodes */
@@ -172,6 +174,10 @@ extern void ntfs_ih_filename_dump(INDEX_HEADER *ih);
 /* the following was added by JPA for use in security.c */
 extern int ntfs_ie_add(ntfs_index_context *icx, INDEX_ENTRY *ie);
 extern int ntfs_index_rm(ntfs_index_context *icx);
+
+extern int ntfs_ih_one_entry(INDEX_HEADER *ih);
+extern int ntfs_ih_zero_entry(INDEX_HEADER *ih);
+extern INDEX_ENTRY *ntfs_ie_dup_novcn(INDEX_ENTRY *ie);
 
 int ntfs_ib_write(ntfs_index_context *icx, INDEX_BLOCK *ib);
 int ntfsck_update_index_entry(ntfs_index_context *ictx);

--- a/include/ntfs-3g/volume.h
+++ b/include/ntfs-3g/volume.h
@@ -348,9 +348,7 @@ struct _ntfs_volume {
 #if CACHE_LOOKUP_SIZE
 	struct CACHE_HEADER *lookup_cache;
 #endif
-#if CACHE_SECURID_SIZE
 	struct CACHE_HEADER *securid_cache;
-#endif
 #if CACHE_LEGACY_SIZE
 	struct CACHE_HEADER *legacy_cache;
 #endif

--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -1819,9 +1819,9 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 	BOOL full;
 	int ret = STATUS_ERROR;
 	ntfs_index_context *icx_add_ie;
-	
+
 	ntfs_log_trace("Entering\n");
-	
+
 	full = ih->index_length == ih->allocated_size;
 	ie_roam = ntfs_ie_dup_novcn(ie);
 	if (!ie_roam)
@@ -1844,11 +1844,16 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 	} else
 		if (ntfs_ib_write(icx, ib))
 			goto out;
-	
+
 	ie_dup = ntfs_ie_dup(icx->entry);
+	if (!ie_dup) {
+		ret = STATUS_ERROR;
+		goto out;
+	}
+
 	ntfs_index_ctx_reinit(icx);
 	icx_add_ie = ntfs_index_ctx_get(icx->ni, NTFS_INDEX_I30, 4);
-	if (!icx)
+	if (!icx_add_ie)
 		goto out;
 
 	ret = ntfs_ie_add(icx_add_ie, ie_roam);
@@ -1859,6 +1864,8 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 	ntfs_index_lookup(&ie_dup->key, le16_to_cpu(ie_dup->key_length), icx);
 out:
 	free(ie_roam);
+	if (ie_dup)
+		free(ie_dup);
 	return ret;
 }
 

--- a/libntfs-3g/volume.c
+++ b/libntfs-3g/volume.c
@@ -270,7 +270,7 @@ static int ntfs_mft_load(ntfs_volume *vol)
 		ntfs_log_perror("Error allocating memory for $MFT");
 		goto error_exit;
 	}
-	vol->mft_ni->mft_no = 0;
+	vol->mft_ni->mft_no = FILE_MFT;
 	vol->mft_ni->mrec = mb;
 	/* Can't use any of the higher level functions yet! */
 	l = ntfs_mst_pread(vol->dev, vol->mft_lcn << vol->cluster_size_bits, 1,
@@ -574,6 +574,7 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 
 	if (ntfs_pread(dev, 0, sector_size, ntfs_boot) != sector_size) {
 		ntfs_log_error("Failed to read boot sector.\n");
+		ntfs_free(ntfs_boot);
 		return 1;
 	}
 
@@ -581,6 +582,7 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 	    ((ntfs_boot->jump[1] != 0x52) && (ntfs_boot->jump[1] != 0x5b)) ||
 	    (ntfs_boot->jump[2] != 0x90)) {
 		ntfs_log_error("Boot sector: Bad jump.\n");
+		ntfs_free(ntfs_boot);
 		return 1;
 	}
 
@@ -614,10 +616,12 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 				res = 0;
 			if (res) {
 				ntfs_log_error("Boot sector: failed to fix boot sector\n");
+				ntfs_free(ntfs_boot);
 				return res;
 			} else
 				fsck_err_fixed();
 		} else if (res) {
+			ntfs_free(ntfs_boot);
 			return 1;
 		}
 	}
@@ -625,6 +629,7 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 	ntfs_log_verbose("Boot sector verification complete. Proceeding to $MFT");
 
 	// todo: if partition, query bios and match heads/tracks?
+	ntfs_free(ntfs_boot);
 	return 0;
 }
 

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -203,7 +203,7 @@ static int ntfsck_check_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 
 char ntfsck_mft_bmp_bit_get(const u64 bit)
 {
-	if (bit >> 3 > fsck_mft_bmp_size)
+	if (bit >> 3 >= fsck_mft_bmp_size)
 		return 0;
 	return ntfs_bit_get(fsck_mft_bmp, bit);
 }


### PR DESCRIPTION
this patch related with https://github.com/namjaejeon/ntfsprogs/issues/35

Found 56 memory leaks in mismatch_index_filename corrupted image. Fixed them.

I'll add more patchsets to resolve memory issues