### PR TITLE
ntfsck: fix memory leak when lookup index

### DIFF
--- a/include/ntfs-3g/index.h
+++ b/include/ntfs-3g/index.h
@@ -78,7 +78,6 @@ typedef int (*COLLATE)(ntfs_volume *vol, const void *data1, int len1,
  * @ir:			index root if @is_in_root or NULL otherwise
  * @actx:		attribute search context if in root or NULL otherwise
  * @ib:			index block if @is_in_root is FALSE or NULL otherwise
- * @prev_ib:		to retain previous index block if new index block read to @ib
  * @ia_na:		opened INDEX_ALLOCATION attribute
  * @parent_pos:		parent entries' positions in the index block
  * @parent_vcn:		entry's parent node or VCN_INDEX_ROOT_PARENT
@@ -125,7 +124,6 @@ typedef struct {
 	INDEX_ROOT *ir;
 	ntfs_attr_search_ctx *actx;
 	INDEX_BLOCK *ib;
-	INDEX_BLOCK *prev_ib;		/* for fsck, retain previous block */
 	ntfs_attr *ia_na;
 	int parent_pos[MAX_PARENT_VCN];  /* parent entries' positions */
 	VCN parent_vcn[MAX_PARENT_VCN]; /* entry's parent nodes */
@@ -174,10 +172,6 @@ extern void ntfs_ih_filename_dump(INDEX_HEADER *ih);
 /* the following was added by JPA for use in security.c */
 extern int ntfs_ie_add(ntfs_index_context *icx, INDEX_ENTRY *ie);
 extern int ntfs_index_rm(ntfs_index_context *icx);
-
-extern int ntfs_ih_one_entry(INDEX_HEADER *ih);
-extern int ntfs_ih_zero_entry(INDEX_HEADER *ih);
-extern INDEX_ENTRY *ntfs_ie_dup_novcn(INDEX_ENTRY *ie);
 
 int ntfs_ib_write(ntfs_index_context *icx, INDEX_BLOCK *ib);
 int ntfsck_update_index_entry(ntfs_index_context *ictx);

--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -325,12 +325,12 @@ static int ntfs_ih_numof_entries(INDEX_HEADER *ih)
 	return n;
 }
 
-int ntfs_ih_one_entry(INDEX_HEADER *ih)
+static int ntfs_ih_one_entry(INDEX_HEADER *ih)
 {
 	return (ntfs_ih_numof_entries(ih) == 1);
 }
 
-int ntfs_ih_zero_entry(INDEX_HEADER *ih)
+static int ntfs_ih_zero_entry(INDEX_HEADER *ih)
 {
 	return (ntfs_ih_numof_entries(ih) == 0);
 }
@@ -380,7 +380,7 @@ static INDEX_ENTRY *ntfs_ie_dup(INDEX_ENTRY *ie)
 	return dup;
 }
 
-INDEX_ENTRY *ntfs_ie_dup_novcn(INDEX_ENTRY *ie)
+static INDEX_ENTRY *ntfs_ie_dup_novcn(INDEX_ENTRY *ie)
 {
 	INDEX_ENTRY *dup;
 	int size = le16_to_cpu(ie->length);
@@ -2242,22 +2242,9 @@ INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
 			ntfs_index_context *ictx)
 {
 	INDEX_ENTRY *entry;
-	INDEX_BLOCK *ib = NULL;
-	BOOL backup;
 	s64 vcn;
 
 	entry = ie;
-
-	if (NVolIsOnFsck(ictx->ni->vol)) {
-		backup = ictx->is_in_root;
-		if (!ictx->is_in_root) {
-			ictx->prev_ib = ictx->ib;
-			ib = ntfs_malloc(ictx->block_size);
-			if (!ib)
-				return NULL;
-			ictx->ib = ib;
-		}
-	}
 
 	do {
 		vcn = ntfs_ie_get_vcn(entry);
@@ -2275,6 +2262,8 @@ INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
 			ictx->pindex++;
 		}
 
+		ictx->parent_pos[ictx->pindex] = 0;
+		ictx->parent_vcn[ictx->pindex] = vcn;
 		if (!ntfs_ib_read(ictx, vcn, ictx->ib)) {
 			int ret;
 
@@ -2293,36 +2282,10 @@ INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
 				/* TODO: ret < 0, inconsistent entry remove */
 				entry = NULL;
 			}
-
-			ictx->parent_pos[ictx->pindex] = 0;
-			ictx->parent_vcn[ictx->pindex] = vcn;
 		} else
 			entry = NULL;
 
 	} while (entry && (entry->ie_flags & INDEX_ENTRY_NODE));
-
-	if (NVolIsOnFsck(ictx->ni->vol)) {
-		if (entry) {
-			if (ictx->prev_ib) {
-				free(ictx->prev_ib);
-				ictx->prev_ib = NULL;
-			}
-		} else {
-			/*
-			 * In case of failure calling ntfs_ib_read(),
-			 * fsck should remove INDEX_ENTRY_NODE of previous entry.
-			 * So, need to preserve prev_ib to point previous entry.
-			 */
-			ictx->is_in_root = backup;
-			ictx->bad_index = TRUE;
-			if (ictx->is_in_root == TRUE && ictx->ib) {
-				free(ictx->ib);
-				ictx->ib = NULL;
-			}
-
-			ictx->pindex--;
-		}
-	}
 
 	return (entry);
 }
@@ -2346,11 +2309,6 @@ INDEX_ENTRY *ntfs_index_walk_up(INDEX_ENTRY *ie,
 			if (!ictx->pindex) {
 
 					/* we have reached the root */
-
-				if (ictx->prev_ib && ictx->prev_ib != ictx->ib) {
-					free(ictx->prev_ib);
-					ictx->prev_ib = NULL;
-				}
 
 				free(ictx->ib);
 				ictx->ib = (INDEX_BLOCK*)NULL;

--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -2315,6 +2315,11 @@ INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
 			 */
 			ictx->is_in_root = backup;
 			ictx->bad_index = TRUE;
+			if (ictx->is_in_root == TRUE && ictx->ib) {
+				free(ictx->ib);
+				ictx->ib = NULL;
+			}
+
 			ictx->pindex--;
 		}
 	}
@@ -2341,6 +2346,11 @@ INDEX_ENTRY *ntfs_index_walk_up(INDEX_ENTRY *ie,
 			if (!ictx->pindex) {
 
 					/* we have reached the root */
+
+				if (ictx->prev_ib && ictx->prev_ib != ictx->ib) {
+					free(ictx->prev_ib);
+					ictx->prev_ib = NULL;
+				}
 
 				free(ictx->ib);
 				ictx->ib = (INDEX_BLOCK*)NULL;

--- a/libntfs-3g/volume.c
+++ b/libntfs-3g/volume.c
@@ -369,6 +369,7 @@ mft_has_no_attr_list:
 				filename);
 		goto error_exit;
 	}
+	ntfs_attr_name_free(&filename);
 
 	/* Get an ntfs attribute for $MFT/$DATA and set it up, too. */
 	vol->mft_na = ntfs_attr_open(vol->mft_ni, AT_DATA, AT_UNNAMED, 0);
@@ -542,6 +543,7 @@ static int ntfs_mftmirr_load(ntfs_volume *vol)
 				filename);
 		goto error_exit;
 	}
+	ntfs_attr_name_free(&filename);
 	ntfs_attr_put_search_ctx(ctx);
 	return 0;
 

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -1559,7 +1559,6 @@ static int ntfsck_initialize_index_attr(ntfs_inode *ni)
 	ntfs_attr *bm_na = NULL;
 	ntfs_attr *ia_na = NULL;
 	ntfs_attr *ir_na = NULL;
-	u8 bmp[8];
 	int ret = STATUS_ERROR;
 
 	/*
@@ -2527,8 +2526,9 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 
 		if (next->ie_flags & INDEX_ENTRY_NODE) {
 			/* read $IA */
-			ictx->ia_na = ntfs_attr_open(dir->ni, AT_INDEX_ALLOCATION,
-						    ictx->name, ictx->name_len);
+			if (!ictx->ia_na)
+				ictx->ia_na = ntfs_attr_open(dir->ni, AT_INDEX_ALLOCATION,
+						ictx->name, ictx->name_len);
 			if (!ictx->ia_na) {
 				ntfs_log_perror("Failed to open index allocation of inode "
 						"%llu", (unsigned long long)dir->ni->mft_no);


### PR DESCRIPTION
when returning to the root following index entry, free ib and prev_ib memory of index context.