### PR TITLE
ntfsck: apply lost+found directory for orphaned inodes

### DIFF
--- a/include/ntfs-3g/layout.h
+++ b/include/ntfs-3g/layout.h
@@ -251,10 +251,12 @@ typedef enum {
  *
  * These are the so far known MFT_RECORD_* flags (16-bit) which contain
  * information about the mft record in which they are present.
- * 
+ *
  * MFT_RECORD_IS_4 exists on all $Extend sub-files.
  * It seems that it marks it is a metadata file with MFT record >24, however,
  * it is unknown if it is limited to metadata files only.
+ * PS) above commens is wrong, sub-files of $Extend which is formatted
+ * in Windows 10 does not have MFT_RECORD_IS_4 flag.
  *
  * MFT_RECORD_IS_VIEW_INDEX exists on every metafile with a non directory
  * index, that means an INDEX_ROOT and an INDEX_ALLOCATION with a name other

--- a/libntfs-3g/inode.c
+++ b/libntfs-3g/inode.c
@@ -514,10 +514,9 @@ int ntfs_inode_close(ntfs_inode *ni)
 	if (ni) {
 		debug_double_inode(ni->mft_no,0);
 		/* do not cache system files : could lead to double entries */
-		if (ni->vol && ni->vol->nidata_cache
-			&& ((ni->mft_no == FILE_root)
-			    || ((ni->mft_no >= FILE_first_user)
-				&& !(ni->mrec->flags & MFT_RECORD_IS_4)))) {
+		if (ni->vol && ni->vol->nidata_cache &&
+				((ni->mft_no == FILE_root) ||
+				 (!utils_is_metadata(ni)))) {
 			/* If we have dirty metadata, write it out. */
 			dirty = NInoDirty(ni) || NInoAttrListDirty(ni);
 			if (dirty) {
@@ -1396,7 +1395,7 @@ void ntfs_inode_update_times(ntfs_inode *ni, ntfs_time_update_flags mask)
 		return;
 	}
 
-	if ((ni->mft_no < FILE_first_user && ni->mft_no != FILE_root) ||
+	if ((utils_is_metadata(ni) && ni->mft_no != FILE_root) ||
 			NVolReadOnly(ni->vol) || !mask)
 		return;
 
@@ -1407,7 +1406,7 @@ void ntfs_inode_update_times(ntfs_inode *ni, ntfs_time_update_flags mask)
 		ni->last_data_change_time = now;
 	if (mask & NTFS_UPDATE_CTIME)
 		ni->last_mft_change_time = now;
-	
+
 	NInoFileNameSetDirty(ni);
 	NInoSetDirty(ni);
 }

--- a/libntfs-3g/security.c
+++ b/libntfs-3g/security.c
@@ -1080,7 +1080,7 @@ static int upgrade_secur_desc(ntfs_volume *vol,
 		 */
 
 	if ((vol->major_ver >= 3)
-	    && (ni->mft_no >= FILE_first_user)) {
+	    && !utils_is_metadata(ni)) {
 		attrsz = ntfs_attr_size(attr);
 		securid = setsecurityattr(vol,
 			(const SECURITY_DESCRIPTOR_RELATIVE*)attr,

--- a/src/utils.c
+++ b/src/utils.c
@@ -903,6 +903,10 @@ int utils_is_metadata(ntfs_inode *inode)
 	if ((num != FILE_root) && (__metadata(vol, num) == 1))
 		return 1;
 
+	if ((inode->flags & (FILE_ATTR_SYSTEM | FILE_ATTR_HIDDEN)) ==
+			(FILE_ATTR_SYSTEM | FILE_ATTR_HIDDEN))
+		return 1;
+
 	return 0;
 }
 


### PR DESCRIPTION
If lost+found does not exist, ntfsck will create it.

And, if orphaned inode can't find proper parent or parent has been deleted, try to add to lost+found.