### PR TITLE
ntfsck: add check for boot sector field if it is zero

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@
 
 # Autoconf
 AC_PREREQ(2.59)
-AC_INIT([ntfsprogs],[2023.6.8],[ntfsprogs-devel@lists.sf.net])
+AC_INIT([ntfsprogs],[2023.6.9],[ntfsprogs-devel@lists.sf.net])
 LIBNTFS_3G_VERSION="89"
 AC_CONFIG_SRCDIR([src/ntfsck.c])
 


### PR DESCRIPTION
Add checking zero field of boot sector.
And remove division operator, substitue shift operator