### PR TITLE
ntfsck: fix return success when boot sector is corrupted

### DIFF
--- a/libntfs-3g/volume.c
+++ b/libntfs-3g/volume.c
@@ -698,6 +698,9 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 			ntfs_free(ntfs_boot);
 			return 1;
 		}
+	} else {
+		ntfs_log_error("Boot sector: invalid boot sector\n");
+		return 1;
 	}
 
 out:


### PR DESCRIPTION
if '-C' option is given and boot sector is corrupted, ntfsck_verify_boot_sector() will return success.
It's wrong, because '-C' option clear NTFS_MNT_FSCK, that function return wrong value.