### PR TITLE
fix several issues

### DIFF
--- a/libntfs-3g/inode.c
+++ b/libntfs-3g/inode.c
@@ -668,6 +668,16 @@ ntfs_inode *ntfs_extent_inode_open(ntfs_inode *base_ni, const leMFT_REF mref)
 		goto out;
 	if (ntfs_file_record_read(base_ni->vol, le64_to_cpu(mref), &ni->mrec, NULL))
 		goto err_out;
+
+	if ((MREF_LE(ni->mrec->base_mft_record) == 0) ||
+			(MREF_LE(ni->mrec->base_mft_record) != base_ni->mft_no)) {
+		ntfs_log_error("Base mft record(%"PRIu64") of inode(%"PRIu64") "
+				"is not a base inode(%"PRIu64")\n",
+				MREF_LE(ni->mrec->base_mft_record), mft_no,
+				base_ni->mft_no);
+		goto err_out;
+	}
+
 	ni->mft_no = mft_no;
 	ni->nr_extents = -1;
 	ni->base_ni = base_ni;

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -2837,6 +2837,7 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 		if (MREF_LE(ni->mrec->base_mft_record) != 0) {
 			ntfs_log_error("Inode(%"PRIu64") is not base inode\n",
 					ni->mft_no);
+			ret = STATUS_ERROR;
 			ntfs_inode_close(ni);
 			goto remove_index;
 		}
@@ -2876,8 +2877,12 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 			ntfs_list_add_tail(&dir->list, &ntfs_dirs_list);
 		} else {
 			ret = ntfs_inode_close_in_dir(ni, ictx->ni);
-			if (ret)
+			if (ret) {
+				ntfs_log_error("Failed to close inode(%"PRIu64")\n",
+						ni->mft_no);
 				ntfs_inode_close(ni);
+				goto remove_index;
+			}
 		}
 	} else {
 		ntfs_log_error("Failed to open inode(%"PRIu64")\n", MREF(mref));

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -779,7 +779,8 @@ static int ntfsck_add_inode_to_parent(ntfs_volume *vol, ntfs_inode *parent_ni,
 		if (ntfsck_check_attr_list(parent_ni))
 			return STATUS_ERROR;
 
-		ntfs_inode_attach_all_extents(parent_ni);
+		if (ntfs_inode_attach_all_extents(parent_ni))
+			return STATUS_ERROR;
 	}
 	ntfsck_set_mft_record_bitmap(parent_ni);
 
@@ -1161,7 +1162,7 @@ stack_of:
 		if (parent_ni) {
 			if (ntfsck_cmp_parent_mft_sequence(parent_ni, fn)) {
 				/* do not add inode to parent */
-				ntfs_log_info("Different seqnence number of parent(%"PRIu64
+				ntfs_log_info("Different sequence number of parent(%"PRIu64
 						") and inode(%"PRIu64")\n",
 						parent_ni->mft_no, ni->mft_no);
 				goto add_to_lostfound;
@@ -2719,7 +2720,8 @@ static int ntfsck_check_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 		if (ntfsck_check_attr_list(ni))
 			goto err_out;
 
-		ntfs_inode_attach_all_extents(ni);
+		if (ntfs_inode_attach_all_extents(ni))
+			goto err_out;
 	}
 
 	ret = ntfsck_check_inode_non_resident(ni);
@@ -2851,7 +2853,7 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 		} else {
 			ret = ntfsck_check_inode(ni, ie, ictx);
 			if (ret) {
-				ntfs_log_info("Failed to check inode(%"PRIu64") "
+				ntfs_log_error("Failed to check inode(%"PRIu64") "
 						"in parent(%"PRIu64") index.\n",
 						ni->mft_no, ictx->ni->mft_no);
 
@@ -2878,6 +2880,7 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 				ntfs_inode_close(ni);
 		}
 	} else {
+		ntfs_log_error("Failed to open inode(%"PRIu64")\n", MREF(mref));
 
 remove_index:
 		check_failed("Index entry(%"PRIu64":%s) "

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -2341,7 +2341,8 @@ static int ntfsck_check_non_resident_attr(ntfs_attr *na, struct rl_size *out_rls
 	 */
 
 	if (na->type == AT_DATA) {
-		if (need_fix == FALSE && !(ni->flags & FILE_ATTR_SYSTEM)) {
+		if (need_fix == FALSE && !(ni->flags & FILE_ATTR_SYSTEM) &&
+				!(ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)) {
 			/* check flag & length for $DATA */
 
 			actx = ntfs_attr_get_search_ctx(ni, NULL);


### PR DESCRIPTION
FIX: modify $FN lookup, previous code implemented to lookup first FN, modify it to find exact $FN
FIX : $DATA attribute can be in directory, so do not check $DATA of directory unlike $DATA of file.
FIX : return checking of ntfs_inode_attach_all_extents()
FIX : add checking of base_mft_record of MFT record
FIX : return checking of ntfs_inode_close()