### PR TITLE
libntfs-3g: fix cache memory leak

### DIFF
--- a/libntfs-3g/cache.c
+++ b/libntfs-3g/cache.c
@@ -320,7 +320,11 @@ struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
 			}
 			if (cache->dohash && current)
 				inserthashindex(cache,current);
+		} else {
+			if (cache->dofree)
+				cache->dofree(item);
 		}
+
 		cache->writes++;
 	}
 	return (current);


### PR DESCRIPTION
when using inode cache(nidata cache) and openning multiple same inode, it may have the potential to memory leak, and it can lead to corruption.

first calling ntfs_inode_close() will put inode to cache, but second calling ntfs_inode_close() will not anything. memory leak occurred here.

when second calling ntfs_inode_close(), ie, already inode is in cache, should call do_free() which is registered in cache initialization.