### PR TITLE
libntfs-3g: compare rootlibdir and libdir in DESTDIR not on build host

### DIFF
--- a/libntfs-3g/Makefile.am
+++ b/libntfs-3g/Makefile.am
@@ -60,15 +60,15 @@ endif
 # And create ldscript or symbolic link from /usr
 install-exec-hook: install-rootlibLTLIBRARIES
 if INSTALL_LIBRARY
-	if [ ! "$(rootlibdir)" -ef "$(libdir)" ]; then \
+	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
 		$(MV) -f "$(DESTDIR)/$(libdir)"/libntfs-3g.so* "$(DESTDIR)/$(rootlibdir)";  \
 	fi
 if GENERATE_LDSCRIPT
-	if [ ! "$(rootlibdir)" -ef "$(libdir)" ]; then \
+	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
 		$(install_sh_PROGRAM) "libntfs-3g.script.so" "$(DESTDIR)/$(libdir)/libntfs-3g.so"; \
 	fi
 else
-	if [ ! "$(rootlibdir)" -ef "$(libdir)" ]; then \
+	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
 		$(LN_S) "$(rootlibdir)/libntfs-3g.so" "$(DESTDIR)/$(libdir)/libntfs-3g.so"; \
 	fi
 endif


### PR DESCRIPTION
* when cross compiling on host without /usr/lib64 this was causing:

libtool: install: aarch64-oe-linux-gcc-ranlib TOPDIR/BUILD/work/mach-oe-linux/ntfsprogs-plus/0.9.1-r0/image/usr/lib64/libntfs-3g.a libtool: warning: remember to run 'libtool --finish /usr/lib64' if [ ! "/usr/lib64" -ef "/usr/lib64" ]; then \
	TOPDIR/BUILD/hosttools/mv -f "TOPDIR/BUILD/work/mach-oe-linux/ntfsprogs-plus/0.9.1-r0/image//usr/lib64"/libntfs-3g.so* "TOPDIR/BUILD/work/mach-oe-linux/ntfsprogs-plus/0.9.1-r0/image//usr/lib64";  \
fi
TOPDIR/BUILD/hosttools/mv: cannot stat 'TOPDIR/BUILD/work/mach-oe-linux/ntfsprogs-plus/0.9.1-r0/image//usr/lib64/libntfs-3g.so*': No such file or directory make[3]: Leaving directory 'TOPDIR/BUILD/work/mach-oe-linux/ntfsprogs-plus/0.9.1-r0/build/libntfs-3g' make[3]: *** [Makefile:1178: install-exec-hook] Error 1